### PR TITLE
Fix AV1 decode failing when no hardware decode support in VT

### DIFF
--- a/src/ffmpeg/codecs.ts
+++ b/src/ffmpeg/codecs.ts
@@ -399,38 +399,38 @@ export class FfmpegCodecs {
 
   // Identify what hardware and operating system environment we're actually running on.
   private probeHwOs(): void {
-      
+
     // Utility to identify what generation of Intel CPU we have if we're on Intel.
-    const intelCpuGeneration = () => {
-      
+    const intelCpuGeneration = (): number => {
+
       // Extract the CPU model.
-      const cpuModel = cpus()[0].model.match(/Intel.*Core.*i\d+-(\d{3,5})/i);
-      
+      const cpuModel = /Intel.*Core.*i\d+-(\d{3,5})/i.exec(cpus()[0].model);
+
       this._cpuGeneration = 0;
-      
-      if(cpuModel && cpuModel[1]) {
-        
+
+      if(cpuModel?.[1]) {
+
         // Grab the individual SKU as both a number and string.
         const skuStr = cpuModel[1];
-        
+
         const skuNum = Number(skuStr);
-        
+
         // Now deduce the CPU generation.
         if(skuNum < 1000) {
-          
+
           // First generation CPUs are three digit SKUs.
           return 1;
         } else if(skuStr.length > 4) {
-          
+
           // For five-digit SKUs, the generation are the leading digits before the last three.
           return Number(skuStr.slice(0, skuStr.length - 3));
         } else {
-          
+
           // Finally, for four-digit SKUs, the generation is the first digit.
           return Number(skuStr.charAt(0));
         }
       }
-    }
+    };
 
     // Take a look at the platform we're on for an initial hint of what we are.
     switch(platform) {
@@ -453,7 +453,7 @@ export class FfmpegCodecs {
             this._cpuGeneration = Number(cpuModel[1]);
           }
         } else {
-          
+
           // Identify what generation of Intel CPU we have if we're on Intel.
           this._cpuGeneration = intelCpuGeneration();
         }
@@ -482,7 +482,7 @@ export class FfmpegCodecs {
         // Identify what generation of Intel CPU we have if we're on Intel.
         if(cpus()[0].model.includes("Intel")) {
 
-          this._cpuGeneration = this.intelCpuGeneration();
+          this._cpuGeneration = intelCpuGeneration();
         }
 
         break;

--- a/src/ffmpeg/codecs.ts
+++ b/src/ffmpeg/codecs.ts
@@ -408,7 +408,7 @@ export class FfmpegCodecs {
       
       this._cpuGeneration = 0;
       
-      if (cpuModel && cpuModel[1]) {
+      if(cpuModel && cpuModel[1]) {
         
         // Grab the individual SKU as both a number and string.
         const skuStr = cpuModel[1];
@@ -416,11 +416,11 @@ export class FfmpegCodecs {
         const skuNum = Number(skuStr);
         
         // Now deduce the CPU generation.
-        if (skuNum < 1000) {
+        if(skuNum < 1000) {
           
           // First generation CPUs are three digit SKUs.
           return 1;
-        } else if (skuStr.length > 4) {
+        } else if(skuStr.length > 4) {
           
           // For five-digit SKUs, the generation are the leading digits before the last three.
           return Number(skuStr.slice(0, skuStr.length - 3));

--- a/src/ffmpeg/codecs.ts
+++ b/src/ffmpeg/codecs.ts
@@ -430,6 +430,7 @@ export class FfmpegCodecs {
           return Number(skuStr.charAt(0));
         }
       }
+      return 0;
     };
 
     // Take a look at the platform we're on for an initial hint of what we are.

--- a/src/ffmpeg/codecs.ts
+++ b/src/ffmpeg/codecs.ts
@@ -280,7 +280,7 @@ export class FfmpegCodecs {
   }
 
   /**
-   * Returns the CPU generation if we're on Linux and have an Intel processor or on macOS and have an Apple Silicon processor.
+   * Returns the CPU generation if we're on Linux and have an Intel processor or on macOS and have an Apple Silicon or Intel processor.
    *
    * @returns Returns the CPU generation or 0 if it can't be detected or an invalid platform.
    */
@@ -399,6 +399,38 @@ export class FfmpegCodecs {
 
   // Identify what hardware and operating system environment we're actually running on.
   private probeHwOs(): void {
+      
+    // Utility to identify what generation of Intel CPU we have if we're on Intel.
+    const intelCpuGeneration = () => {
+      
+      // Extract the CPU model.
+      const cpuModel = cpus()[0].model.match(/Intel.*Core.*i\d+-(\d{3,5})/i);
+      
+      this._cpuGeneration = 0;
+      
+      if (cpuModel && cpuModel[1]) {
+        
+        // Grab the individual SKU as both a number and string.
+        const skuStr = cpuModel[1];
+        
+        const skuNum = Number(skuStr);
+        
+        // Now deduce the CPU generation.
+        if (skuNum < 1000) {
+          
+          // First generation CPUs are three digit SKUs.
+          return 1;
+        } else if (skuStr.length > 4) {
+          
+          // For five-digit SKUs, the generation are the leading digits before the last three.
+          return Number(skuStr.slice(0, skuStr.length - 3));
+        } else {
+          
+          // Finally, for four-digit SKUs, the generation is the first digit.
+          return Number(skuStr.charAt(0));
+        }
+      }
+    }
 
     // Take a look at the platform we're on for an initial hint of what we are.
     switch(platform) {
@@ -420,6 +452,10 @@ export class FfmpegCodecs {
 
             this._cpuGeneration = Number(cpuModel[1]);
           }
+        } else {
+          
+          // Identify what generation of Intel CPU we have if we're on Intel.
+          this._cpuGeneration = intelCpuGeneration();
         }
 
         break;
@@ -446,32 +482,7 @@ export class FfmpegCodecs {
         // Identify what generation of Intel CPU we have if we're on Intel.
         if(cpus()[0].model.includes("Intel")) {
 
-          // Extract the CPU model.
-          const cpuModel = /Intel.*Core.*i\d+-(\d{3,5})/i.exec(cpus()[0].model);
-
-          this._cpuGeneration = 0;
-
-          if(cpuModel?.[1]) {
-
-            // Grab the individual SKU as both a number and string.
-            const skuStr = cpuModel[1];
-            const skuNum = Number(skuStr);
-
-            // Now deduce the CPU generation.
-            if(skuNum < 1000) {
-
-              // First generation CPUs are three digit SKUs.
-              this._cpuGeneration = 1;
-            } else if(skuStr.length > 4) {
-
-              // For five-digit SKUs, the generation are the leading digits before the last three.
-              this._cpuGeneration = Number(skuStr.slice(0, skuStr.length - 3));
-            } else {
-
-              // Finally, for four-digit SKUs, the generation is the first digit.
-              this._cpuGeneration = Number(skuStr.charAt(0));
-            }
-          }
+          this._cpuGeneration = this.intelCpuGeneration();
         }
 
         break;

--- a/src/ffmpeg/options.ts
+++ b/src/ffmpeg/options.ts
@@ -250,8 +250,8 @@ export class FfmpegOptions {
     this.debug = options.debug ?? false;
 
     // Ensure no errors will occur from decodeCodec undefined
-    this.decodeCodec = options.decodeCodec ?? (() => "");
-    
+    this.decodeCodec = options.decodeCodec ?? (() : string => "");
+
     this.log = options.log;
     this.name = options.name;
 
@@ -341,44 +341,49 @@ export class FfmpegOptions {
         return true;
       };
 
+      const codec = this.decodeCodec();
+
       switch(this.codecSupport.hostSystem) {
 
         case "macOS.Apple":
-          
+
           // AV1 hardware decoding is supported on M3 and above
           // We explicitly disable it for M2 and below and tell the user as proceeding with hardware decoding pipeline will fail
-          if(this.decodeCodec === "av1" && this.codecSupport.cpuGeneration < 3) {
-                  
-            this.log.error("Disabling hardware-accelerated decoding. Your machine does not have hardware decoding support for the " + this.decodeCodec + " codec. Try changing the camera encoding type from \"Advanced\" to \"Enhanced\"");
-                  
+          if((codec === "av1") && (this.codecSupport.cpuGeneration < 3)) {
+
+            this.log.error("Disabling hardware-accelerated decoding. Your machine does not have hardware decoding support for the " + codec +
+              " codec. Try changing the camera encoding type from \"Advanced\" to \"Enhanced\"");
+
             this.config.hardwareDecoding = false;
-              
+
             break;
           }
-          
+
           // Intentionally fall through
-              
+
         case "macOS.Intel":
 
           // AV1 hardware decoding is never supported on Intel
           // We explicitly disable it for M2 and below and tell the user as proceeding with hardware decoding pipeline will fail
-          if(this.decodeCodec === "av1") {
-                  
-            this.log.error("Disabling hardware-accelerated decoding. Your machine does not have support for hardware decoding for the " + this.decodeCodec + " codec. Try changing the camera encoding type from \"Advanced\" to \"Enhanced\"");
-                  
+          if(codec === "av1") {
+
+            this.log.error("Disabling hardware-accelerated decoding. Your machine does not have support for hardware decoding for the " + codec +
+              " codec. Try changing the camera encoding type from \"Advanced\" to \"Enhanced\"");
+
             this.config.hardwareDecoding = false;
-                  
+
             break;
           }
-              
+
           // It is safe to leave hardware decoding in place for h264 and h265/hevc because videotoolbox will
           // fallback to software internally, still supporting hardware surface outputs, however we should
           // inform the user that only partial hardware support is available pre-kaby lake
-          if(this.decodeCodec === "h265" && this.codecSupport.cpuGeneration < 7) {
-            
-            this.log.warn("Pre-Kaby Lake machines will use partial hardware decoding as determined by videotoolbox. For full hardware decoding, try changing the camera encoding type to \"Standard\".");
+          if((this.decodeCodec === "h265") && (this.codecSupport.cpuGeneration < 7)) {
+
+            this.log.warn("Pre-Kaby Lake machines will use partial hardware decoding as determined by videotoolbox. " +
+              "For full hardware decoding, try changing the camera encoding type to \"Standard\".");
           }
-                  
+
           // Verify that we have hardware-accelerated decoding available to us for other codecs.
           validateHwAccel("videotoolbox");
 

--- a/src/ffmpeg/options.ts
+++ b/src/ffmpeg/options.ts
@@ -33,6 +33,7 @@ import type { HomebridgePluginLogging } from "../util.js";
  * @property codecSupport         - FFmpeg codec capabilities and hardware support.
  * @property crop                 - Optional. Cropping rectangle for output video.
  * @property debug                - Optional. Enable debug logging.
+ * @property decodeCodec          - Optional. Codec to be decoded. Used to assist in configuring our hardware acceleration support.
  * @property hardwareDecoding     - Enable hardware-accelerated video decoding if available.
  * @property hardwareTranscoding  - Enable hardware-accelerated video encoding if available.
  * @property log                  - Logging interface for output and errors.
@@ -46,6 +47,7 @@ import type { HomebridgePluginLogging } from "../util.js";
  *   codecSupport: ffmpegCodecs,
  *   crop: { width: 1, height: 1, x: 0, y: 0 },
  *   debug: false,
+ *   decodeCodec: "h264",
  *   hardwareDecoding: true,
  *   hardwareTranscoding: true,
  *   log,
@@ -62,6 +64,7 @@ export interface FfmpegOptionsConfig {
   codecSupport: FfmpegCodecs;
   crop?: { height: number; width: number; x: number; y: number };
   debug?: boolean;
+  decodeCodec?: () => string;
   hardwareDecoding: boolean;
   hardwareTranscoding: boolean;
   log: HomebridgePluginLogging | Logging;
@@ -215,6 +218,11 @@ export class FfmpegOptions {
   public readonly debug: boolean;
 
   /**
+   * Codec that is being decoded.
+   */
+  public readonly decodeCodec: () => string;
+
+  /**
    * Logging interface for output and errors.
    */
   public readonly log: HomebridgePluginLogging | Logging;
@@ -241,6 +249,9 @@ export class FfmpegOptions {
     this.config = options;
     this.debug = options.debug ?? false;
 
+    // Ensure no errors will occur from decodeCodec undefined
+    this.decodeCodec = options.decodeCodec ?? (() => "");
+    
     this.log = options.log;
     this.name = options.name;
 
@@ -333,9 +344,42 @@ export class FfmpegOptions {
       switch(this.codecSupport.hostSystem) {
 
         case "macOS.Apple":
+          
+          // AV1 hardware decoding is supported on M3 and above
+          // We explicitly disable it for M2 and below and tell the user as proceeding with hardware decoding pipeline will fail
+          if(this.decodeCodec === "av1" && this.codecSupport.cpuGeneration < 3) {
+                  
+            this.log.error("Disabling hardware-accelerated decoding. Your machine does not have hardware decoding support for the " + this.decodeCodec + " codec. Try changing the camera encoding type from \"Advanced\" to \"Enhanced\"");
+                  
+            this.config.hardwareDecoding = false;
+              
+            break;
+          }
+          
+          // Intentionally fall through
+              
         case "macOS.Intel":
 
-          // Verify that we have hardware-accelerated decoding available to us.
+          // AV1 hardware decoding is never supported on Intel
+          // We explicitly disable it for M2 and below and tell the user as proceeding with hardware decoding pipeline will fail
+          if(this.decodeCodec === "av1") {
+                  
+            this.log.error("Disabling hardware-accelerated decoding. Your machine does not have support for hardware decoding for the " + this.decodeCodec + " codec. Try changing the camera encoding type from \"Advanced\" to \"Enhanced\"");
+                  
+            this.config.hardwareDecoding = false;
+                  
+            break;
+          }
+              
+          // It is safe to leave hardware decoding in place for h264 and h265/hevc because videotoolbox will
+          // fallback to software internally, still supporting hardware surface outputs, however we should
+          // inform the user that only partial hardware support is available pre-kaby lake
+          if (this.decodeCodec === "h265" && this.codecSupport.cpuGeneration < 7) {
+            
+            this.log.warn("Pre-Kaby Lake machines will use partial hardware decoding as determined by videotoolbox. For full hardware decoding, try changing the camera encoding type to \"Standard\".");
+          }
+                  
+          // Verify that we have hardware-accelerated decoding available to us for other codecs.
           validateHwAccel("videotoolbox");
 
           break;

--- a/src/ffmpeg/options.ts
+++ b/src/ffmpeg/options.ts
@@ -47,7 +47,7 @@ import type { HomebridgePluginLogging } from "../util.js";
  *   codecSupport: ffmpegCodecs,
  *   crop: { width: 1, height: 1, x: 0, y: 0 },
  *   debug: false,
- *   decodeCodec: "h264",
+ *   decodeCodec: () =>  "h264",
  *   hardwareDecoding: true,
  *   hardwareTranscoding: true,
  *   log,
@@ -378,7 +378,7 @@ export class FfmpegOptions {
           // It is safe to leave hardware decoding in place for h264 and h265/hevc because videotoolbox will
           // fallback to software internally, still supporting hardware surface outputs, however we should
           // inform the user that only partial hardware support is available pre-kaby lake
-          if((this.decodeCodec === "h265") && (this.codecSupport.cpuGeneration < 7)) {
+          if((codec === "h265") && (this.codecSupport.cpuGeneration < 7)) {
 
             this.log.warn("Pre-Kaby Lake machines will use partial hardware decoding as determined by videotoolbox. " +
               "For full hardware decoding, try changing the camera encoding type to \"Standard\".");
@@ -513,7 +513,7 @@ export class FfmpegOptions {
     // 4. Hardware decode -> Hardware encode: No transfer needed, stay in hardware.
     const needsUpload = !options.hardwareDecoding && options.hardwareTranscoding;
     const needsDownload = options.hardwareDecoding && !options.hardwareTranscoding;
-
+    
     if(needsUpload) {
 
       // We need to download frames from the GPU to system memory for software encoding.

--- a/src/ffmpeg/options.ts
+++ b/src/ffmpeg/options.ts
@@ -374,7 +374,7 @@ export class FfmpegOptions {
           // It is safe to leave hardware decoding in place for h264 and h265/hevc because videotoolbox will
           // fallback to software internally, still supporting hardware surface outputs, however we should
           // inform the user that only partial hardware support is available pre-kaby lake
-          if (this.decodeCodec === "h265" && this.codecSupport.cpuGeneration < 7) {
+          if(this.decodeCodec === "h265" && this.codecSupport.cpuGeneration < 7) {
             
             this.log.warn("Pre-Kaby Lake machines will use partial hardware decoding as determined by videotoolbox. For full hardware decoding, try changing the camera encoding type to \"Standard\".");
           }


### PR DESCRIPTION
#AV1 decode fails when VT is attempted but hardware support is not available in VT. This does not happen for h264/hevc - those encoders fail gracefully because VT falls back to software internally, still allowing ffmpeg to see the output as hardware surfaces. in the case of AV1, VT does not fall back gracefully, so ffmpeg will fail. AV1 hardware support in VT is available on M3 Apple Silicon and newer (and no Intel Macs).

closes #5 
related to hjdhjd/homebridge-unifi-protect/issues/1283
