### PR TITLE
fix: include crop filter in software transcoding path

### DIFF
--- a/src/ffmpeg/options.ts
+++ b/src/ffmpeg/options.ts
@@ -962,6 +962,12 @@ export class FfmpegOptions {
     // Add any required hardware transfer filters. This handles downloading from GPU if we were hardware decoding.
     pixelFilters.push(...this.getHardwareTransferFilters(options));
 
+    // Add the crop filter if configured.
+    if(this.config.crop) {
+
+      pixelFilters.push(this.cropFilter);
+    }
+
     // Set our FFmpeg pixel-level filters:
     //
     // scale=-2:min(ih\,height)          Scale the video to the size that's being requested while respecting aspect ratios and ensuring our final dimensions are


### PR DESCRIPTION
## Problem

The `defaultVideoEncoderOptions` method does not include the crop filter in its video filter chain. This means crop settings are silently ignored on systems without hardware encoding support (e.g. Linux/Docker without GPU passthrough).

The crop works correctly in snapshots (handled separately in `protect-snapshot.ts`) and in the hardware-accelerated transcoding path, but not when software transcoding is used for livestreams.

## Fix

Adds the crop filter to the `defaultVideoEncoderOptions` method, placed after hardware transfer filters and before the scale filter — matching the existing behavior in the hardware-accelerated path.

## Testing

Tested on a Synology DSM running Homebridge in Docker (no hardware transcoding available). With this fix, crop settings are correctly applied to livestreams when using software transcoding.