### PR TITLE
fix(ffmpeg): pin nv12 before hwupload on macOS

### DIFF
--- a/src/ffmpeg/options.ts
+++ b/src/ffmpeg/options.ts
@@ -655,10 +655,11 @@ export class FfmpegOptions {
         case "macOS.Apple":
         case "macOS.Intel":
 
-          // FFmpeg 8.x on macOS requires explicit upload when moving from software decoding to VideoToolbox encoding.
+          // FFmpeg 8.x on macOS requires explicit upload when moving from software decoding to VideoToolbox encoding. We pin nv12 ahead of it so the frames context
+          // gets nv12 as its sw_format - otherwise it inherits the decoder's yuv420p and any later hwdownload, which can only emit that exact sw_format, fails.
           if(this.#codecSupport.ffmpegAtLeast(8)) {
 
-            filters.push("hwupload");
+            filters.push("format=nv12", "hwupload");
           }
 
           break;


### PR DESCRIPTION
Title: fix(ffmpeg): pin nv12 before hwupload on macOS

Hardware transcoding plus any CPU-side filter after `scale_vt` exits 234 (I hit it via minterpolate in homebridge-unifi-protect):

```
[hwdownload] Invalid output format nv12 for hwframe download.
```

The bare `hwupload` leaves the frames context on the software decoder's yuv420p, and hwdownload can only give back that exact sw_format. Pinning the format up front lines both ends up:

```diff
-filters.push("hwupload");
+filters.push("format=nv12", "hwupload");
```

nv12 is what VideoToolbox wants anyway, so no extra conversion. Hardware decode already produced nv12, so nothing changes there.

Repro without Homebridge:

```bash
ffmpeg -f lavfi -i testsrc2=size=1280x720:rate=30 -init_hw_device videotoolbox=hw -filter_hw_device hw \
  -filter:v "hwupload, scale_vt=-2:360, hwdownload, format=nv12" -frames:v 2 -f null -
```

Tested on Apple Silicon with ffmpeg 8.1.2-homebridge-darwin-arm64.